### PR TITLE
主进程在开发环境启用 sourcemap

### DIFF
--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -15,7 +15,6 @@ let mainConfig = {
   externals: [
     ...Object.keys(dependencies || {})
   ],
-  devtool: "source-map",
   module: {
     rules: [
       {
@@ -69,6 +68,7 @@ let mainConfig = {
  * Adjust mainConfig for development settings
  */
 if (process.env.NODE_ENV !== 'production') {
+  mainConfig.devtool = "source-map";
   mainConfig.plugins.push(
     new webpack.DefinePlugin({
       '__static': `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`


### PR DESCRIPTION
主进程仅在开发环境启用 sourcemap 用于调试，在生产环境中禁用 sourcemap 。